### PR TITLE
Make bucket setup optional

### DIFF
--- a/tasks/configure_server.yml
+++ b/tasks/configure_server.yml
@@ -17,6 +17,7 @@
 
 - name: Create Minio Buckets
   include_tasks: create_minio_buckets.yml
+  when: minio_buckets | length > 0
 
 - name: Create Minio Users
   include_tasks: create_minio_user.yml


### PR DESCRIPTION
When no buckets are configured we do not need to install the tooling at all.